### PR TITLE
Output changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Version Bump
 More Github Actions changes
 ## [0.0.3] - 2021-03-08
 Github Actions changes
-## [0.0.2] - 2021-03-08 
+## [0.0.2] - 2021-03-08
 Fixes for SecretsManagement RC1
 ## [0.0.1] - 2020-10-27
 Initial Preview Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.2] - 2021-06-10
+Default to Hashtable output.
+## [1.0.1] - 2021-06-04
+Improve Logging. Make Health Checks optional.
+Suggested by [Mounting to an existing path in Vault #7](https://github.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/issues/7)
+## [1.0.0] - 2021-06-04
+Update About; remove Preview Tag
+## [0.0.11] - 2021-03-16
+More Bug fixes
+## [0.0.10] - 2021-03-16
+Fix login logic bug
+## [0.0.9] - 2021-03-15
+Better Token Management; Retrieving Metadata
+## [0.0.8] - 2021-03-13
+Support Hashtable; Creating Metadata; Removing Vaults
+## [0.0.7] - 2021-03-09
+Create New Vault; Fix Test-SecretVault
+## [0.0.6] - 2021-03-08
+Required Secrets Version; Fix folder structure
+## [0.0.5] - 2021-03-08
+Version Bump
+## [0.0.4] - 2021-03-08
+More Github Actions changes
+## [0.0.3] - 2021-03-08
+Github Actions changes
+## [0.0.2] - 2021-03-08 
+Fixes for SecretsManagement RC1
+## [0.0.1] - 2020-10-27
+Initial Preview Release

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $VaultParameters @{ ...
 ```
 The Default is to return it as a Hashtable.
 
-When setting secrets in your vault. You may provide either a single text value or a hashtable to the `-Secret` parameter.
+When setting secrets in your vault, You may provide either a single text value or a hashtable to the `-Secret` parameter.  
 
 ## KV Version 2 distinctions
 - Get-Secret only retrieves the newest secret

--- a/README.md
+++ b/README.md
@@ -21,15 +21,22 @@ $VaultParameters = @{ VaultServer = 'https://vault-cluster.domain.local'
    KVVersion = 'v1'}
 ```
 
+If you stored your secrets in a flat structure (i.e. no slashes in your path).
+You may want to return all secrets as a PSCredential. You can do this by providing the following:
+```powershell
+$VaultParameters @{ ...
+    OutputType = 'PSCredential'
+}
+```
+The Default is to return it as a Hashtable.
+
+When setting secrets in your vault. You may provide either a single text value or a hashtable to the `-Secret` parameter.
+
 ## KV Version 2 distinctions
 - Get-Secret only retrieves the newest secret
 - Get-SecretInfo retrieves the Hashicorp Metadata.
 - Set-Secret Adds/Updates without CheckAndSet. Althought it can be passed with `-Metadata @{cas=<versionNumber>}`
 - Remove-Secret Completely Removes the secret and all versions
-
-## TO DO
-- Allow token updating
-- Allow options for KV2 version retrieval
 
 
 [GitHubSuper-Linter]: https://github.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/workflows/ci/badge.svg

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $VaultParameters @{ ...
 ```
 The Default is to return it as a Hashtable.
 
-When setting secrets in your vault, You may provide either a single text value or a hashtable to the `-Secret` parameter.  
+You may provide either a single text string or a hashtable to the `-Secret` parameter.
 
 ## KV Version 2 distinctions
 - Get-Secret only retrieves the newest secret

--- a/src/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psd1
+++ b/src/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion     = '1.0.1'
+    ModuleVersion     = '1.0.2'
     RootModule        = 'SecretManagement.Hashicorp.Vault.KV.Extension.psm1'
     FunctionsToExport = @('Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault', 'Unregister-SecretVault')
 }

--- a/src/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
+++ b/src/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
@@ -605,7 +605,12 @@ function Test-SecretVault {
         }
 
         if ($Null -eq [HashicorpVaultKV]::VaultToken) {
+            Write-Verbose "Retrieving a Token for authenticating to Vault"
             Invoke-VaultToken
+        }
+        if ($Null -eq [HashicorpVaultKV]::OutputType) {
+            [HashicorpVaultKV]::OutputType = 'Hashtable'
+            Write-Verbose "Setting Default Output Type to Hashtable"
         }
 
         #The rest runs provided the top 4 items are correct

--- a/src/SecretManagement.Hashicorp.Vault.KV.psd1
+++ b/src/SecretManagement.Hashicorp.Vault.KV.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion        = '1.0.1'
+    ModuleVersion        = '1.0.2'
     CompatiblePSEditions = @('Desktop', 'Core')
     GUID                 = '5dbf943d-d9c0-4db5-88a2-1995043a6305'
     Author               = 'Josh Corrick'
@@ -22,40 +22,7 @@
             LicenseUri                 = 'https://raw.githubusercontent.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/main/LICENSE'
             ProjectUri                 = 'https://github.com/joshcorr/SecretManagement.Hashicorp.Vault.KV'
             # IconUri = ''
-            ReleaseNotes               = @'
-v1.0.0
-Update About, and remove Preview Tag
-
-v0.0.10 - v0.0.11
-Fix login logic bug
-
-v0.0.9
-Better Token Management; Retrieving Metadata
-
-v0.0.8
-Support Hashtable; Creating Metadata; Removing Vaults
-
-v0.0.7
-Create New Vault; Fix Test-SecretVault
-
-v0.0.6
-Required Secrets Version; Fix folder structure
-
-v0.0.5
-Version Bump
-
-v0.0.4
-More Github Actions changes
-
-v0.0.3
-Github Actions changes
-
-v0.0.2
-Fixes for SecretsManagement RC1
-
-v0.0.1
-Initial Preview Release
-'@
+            ReleaseNotes               = ReleaseNotes = 'https://raw.githubusercontent.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/main/CHANGELOG.md'
         }
     }
 }

--- a/src/SecretManagement.Hashicorp.Vault.KV.psd1
+++ b/src/SecretManagement.Hashicorp.Vault.KV.psd1
@@ -22,7 +22,7 @@
             LicenseUri                 = 'https://raw.githubusercontent.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/main/LICENSE'
             ProjectUri                 = 'https://github.com/joshcorr/SecretManagement.Hashicorp.Vault.KV'
             # IconUri = ''
-            ReleaseNotes               = ReleaseNotes = 'https://raw.githubusercontent.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/main/CHANGELOG.md'
+            ReleaseNotes               = 'https://raw.githubusercontent.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/main/CHANGELOG.md'
         }
     }
 }

--- a/src/en-us/about_SecretManagement.Hashicorp.Vault.KV.Extension.Help.txt
+++ b/src/en-us/about_SecretManagement.Hashicorp.Vault.KV.Extension.Help.txt
@@ -24,6 +24,12 @@ $VaultParameters = @{ VaultServer = 'https://vault-cluster.domain.local'
 Register-SecretVault -ModuleName SecretManagement.Hashicorp.Vault.KV -Name PowerShellTest
 -VaultParameters $VaultParameters
 
+If you stored you secrets in a flat structure (i.e. no slashes in your path).
+You may want to return all secrets as a PSCredential. You can do this by providing the following:
+$VaultParameters @{ ...
+    OutputType = 'PSCredential'
+}
+
 KV Version 2 distinctions
 - Get-Secret only retrieves the newest secret
 - Get-SecretInfo retrieves the Hashicorp Metadata.
@@ -37,6 +43,8 @@ REGISTRATION PARAMETERS
         VaultToken - The Vault Token you are using. This must be input as ConvertFrom-SecureString output.
         VaultAPIVersion - Defaults to v1
         KVVersion - Defaults to v2
+        OutputType - Defaults to Hashtable
+        Verbose - Supported by SecretManagement
 
 SUPPORTED AUTHENTICATION TYPES
     Hashicorp supports multiple ways of authenticating to retrieve a token.
@@ -45,6 +53,14 @@ SUPPORTED AUTHENTICATION TYPES
         LDAP
         UserPass
         Token
+
+SUPPORTED OUTPUT TYPES
+    This extension currently supports to major output types:
+        Hashtable (default)
+        PSCredential
+
+    By default SecretManagement turns any plaintext password field into a SecureString.
+    Use -AsPlainText switch to return the hashtable in plaintext.
 
 
 KEYWORDS


### PR DESCRIPTION
Realized that most Vault users will not want a PSCredential object, and would expect a Hashtable. 
Making Hashtable the default.