### PR TITLE
fix: json depth in Set-Secret

### DIFF
--- a/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
+++ b/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
@@ -281,7 +281,7 @@ function New-VaultAPIBody {
                 $Tempbody['options'] = $options
             }
         }
-        $OutputBody = $Tempbody | ConvertTo-Json
+        $OutputBody = $Tempbody | ConvertTo-Json -Depth 10
         return $OutputBody
     } catch {
         throw


### PR DESCRIPTION
Using multilevel json value for a secret fails because default depth for `ConvertTo-Json` is 2 and this is used before creating the API request body. 

https://github.com/joshcorr/SecretManagement.Hashicorp.Vault.KV/issues/17