### PR TITLE
Improvement/unattended authentication issue38

### DIFF
--- a/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psd1
+++ b/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion     = '2.0.1'
+    ModuleVersion     = '2.0.2'
     RootModule        = 'SecretManagement.Hashicorp.Vault.KV.Extension.psm1'
     FunctionsToExport = @('Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault', 'Unlock-SecretVault', 'Unregister-SecretVault')
 }

--- a/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
+++ b/SecretManagement.Hashicorp.Vault.KV/SecretManagement.Hashicorp.Vault.KV.Extension/SecretManagement.Hashicorp.Vault.KV.Extension.psm1
@@ -155,8 +155,6 @@ function Invoke-VaultToken {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [string] $Login,
-        [Parameter()]
         [SecureString] $Password,
         [Parameter()]
         [string] $VaultName,
@@ -174,13 +172,13 @@ function Invoke-VaultToken {
         Write-Verbose "Retrieving a Token for authenticating to Vault"
         $RenewToken = $false
         #continue
-    } elseif ($Null -ne $script:VaultToken -and $script:TokenExpireTime -lt (Get-Date) -and -not $script:RootToken) {
+    } elseif ($Null -ne $script:VaultToken -and $script:TokenExpireTime -lt (Get-date) -and -not $script:RootToken) {
         # Retrieve a new token if expired
         Write-Verbose "Token Expired at $($script:TokenExpireTime). Retieving a new token"
         $script:VaultToken = $null
         $RenewToken = $false
         #continue
-    } elseif ($Null -ne $script:VaultToken -and (New-TimeSpan -Start (Get-Date) -End ($script:TokenExpireTime)).Minutes -le 1 -and $script:TokenRenewable) {
+    } elseif ($Null -ne $script:VaultToken -and (New-TimeSpan -Start (Get-date) -End ($script:TokenExpireTime)).Minutes -le 1 -and $script:TokenRenewable) {
         # Renew a new token if about to expire
         Write-Verbose "Token about to Expire at $($script:TokenExpireTime). Renewing the token for $($script:TokenLifespan) seconds."
         $RenewToken = $true
@@ -198,9 +196,7 @@ function Invoke-VaultToken {
     $AuthType = $script:VaultAuthType
 
     if ($Password -and $AuthType -ne 'Token' -and -not $RenewToken) {
-        if ($Null -eq $Login) {
-            $Login = Read-Host -Prompt "What is the $(if($AuthType -eq 'Approle'){'Role-Id'} else {'Username'})?"
-        }
+        $Login = Read-Host -Prompt "What is the $(if($AuthType -eq 'Approle'){'Role-Id'} else {'Username'})?"
         $Credential = [System.Management.Automation.PSCredential]::new($Login, $Password)
     }
     switch ($script:VaultAuthType) {
@@ -568,8 +564,8 @@ function Get-SecretInfo {
         $Filter = "*$Filter"
         $VaultSecrets = Resolve-VaultSecretPath -VaultName $VaultName @VerboseSplat
         $VaultSecrets |
-        Where-Object { $PSItem -like $Filter } |
-        ForEach-Object {
+            Where-Object { $PSItem -like $Filter } |
+            ForEach-Object {
             if ($script:KVVersion -eq 'v1') {
                 $Metadata = $null
             } else {
@@ -742,8 +738,6 @@ function Unlock-SecretVault {
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipelineByPropertyName)]
-        [string] $Login,
-        [Parameter(ValueFromPipelineByPropertyName)]
         [SecureString] $Password,
         [Parameter(ValueFromPipelineByPropertyName)]
         [Alias('Name')]
@@ -753,7 +747,7 @@ function Unlock-SecretVault {
         [hashtable] $AdditionalParameters
     )
     process {
-        Invoke-VaultToken -Login $Login -Password $Password -VaultName $VaultName -AdditionalParameters $AdditionalParameters
+        Invoke-VaultToken -Password $Password -VaultName $VaultName -AdditionalParameters $AdditionalParameters
     }
 }
 function Unregister-SecretVault {


### PR DESCRIPTION
Added Login parameter to AdditionalParameters. If Login is found when invoking Unlock-SecretVault with a supplied [SecureString]Password, a credential object is created to authenticate. If no Login supplied, existing Read-Host functionality is maintained. Works with both userpass and AppRole authentication methods supported.

Example of use: (these are generated UUIDs, not ones in use anywhere, provided as examples)
```pwsh
Register-SecretVault -ModuleName SecretManagement.Hashicorp.Vault.KV -Name "secret" -VaultParameters @{VaultServer = "http://localhost:8200"; VaultAuthType = "AppRole"; KVVersion = 'v1'; Login = "673f53a5-d513-459d-961d-e22771ddf147"}
Unlock-SecretVault -Name "secret" -Password (ConvertTo-SecureString "3c1f10e8-9899-4e75-b3f2-6a3752874562" -AsPlainText -Force)
```
